### PR TITLE
PEP8 and Better Error Handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,14 @@ sudo: false
 matrix:
   include:
   - python: "2.7"
+beforeinstall:
+    - apt-get update
+    - apt-get install colordiff
 install:
   - pip install -e .
   - pip install -r requirements-test.txt
 script:
+  - ./run_autopep8.sh check
   - py.test tests --cov=tight tests/
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,10 @@ Tight is a microframework created and optimized for serverless runtimes. With ``
 **Tight currently supports AWS Lambda and the Python2.7 runtime.**
 
 The best way to get started with Tight is to follow the `tutorial <http://tight-cli.readthedocs.io/en/latest/topics/tutorial.html>`_, which will guide you through the process of building and deploying an app. There are also references for both `tight <http://tight-cli.readthedocs.io/en/latest/topics/tight_reference.html>`_ and `tight-cli <http://tight-cli.readthedocs.io/en/latest/topics/reference.html>`_.
+
+###########
+Development
+###########
+
+* `pip install -e .`
+* `pip install -r requirements.txt`

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ pytest==3.0.5
 python-dateutil==2.6.0
 six==1.10.0
 pytest-cov
+autopep8

--- a/run_autopep8.sh
+++ b/run_autopep8.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -e
+declare -r CONF="setup.cfg"
+declare -r ARGS=(ignore select max-line-length)
+declare -r HELP="usage: $0 [fix]
+
+Run autopep8 on all staged and unstaged *.py files in the git index
+
+If you specified \"fix\" as an argument, it will run autopep8 on all *.py files
+in the repository, regardless of staging.
+"
+
+
+# Parse a value out of the CONF file and return it with a '--' in front
+get_arg() {
+    set +e
+    local _value=$(grep $1 $CONF)
+    set -e
+    if [ "$_value" ]; then
+        echo "--$_value"
+    fi
+}
+
+main() {
+    local _tests="tests"
+    local _autopep="autopep8 -j 0 -i -r"
+    local _autopep_diff="autopep8 -d"
+    for _arg in ${ARGS[@]}; do
+        _autopep="$_autopep $(get_arg $_arg)"
+    done
+    if [ "$1" == "-h" ]; then
+        echo "$HELP"
+    elif [ "$1" == "fix" ]; then
+        local _package=$(basename $(python -c "import os,sys; print(os.path.realpath(os.getcwd()))" "${1}"))
+        find $_package -name '*.py' | xargs $_autopep
+        find $_tests -name '*.py' | xargs $_autopep
+    elif [ "$1" == "check" ]; then
+        local _package=$(basename $(python -c "import os,sys; print(os.path.realpath(os.getcwd()))" "${1}"))
+        local _package_result=$(find $_package -name '*.py' | xargs $_autopep_diff)
+        local _tests_result=$(find $_tests -name '*.py' | xargs $_autopep_diff)
+
+        local _exit="0"
+
+        if [[ !  -z $_package_result ]]; then
+            _exit="1"
+            which colordiff > /dev/null 2>&1
+            if [ $? -eq 0 ]; then
+                echo -- "$_package_result" | colordiff
+            else
+                echo -- "$_package_result"
+            fi
+        fi
+
+        if [[ !  -z $_tests_result ]]; then
+            which colordiff > /dev/null 2>&1
+            _exit=1
+            if [ $? -eq 0 ]; then
+                echo -- "$_tests_result" | colordiff
+            else
+                echo -- "$_tests_result"
+            fi
+        fi
+
+        exit "$_exit"
+    else
+        local _diff=$(git diff --name-only --diff-filter=ACMRT | grep '.py$')
+        if [ "$_diff" ]; then
+            echo "$_diff" | xargs $_autopep
+        fi
+        local _diff_cached=$(git diff --cached --name-only --diff-filter=ACMRT | grep '.py$')
+        if [ "$_diff_cached" ]; then
+            echo "$_diff_cached" | xargs $_autopep
+        fi
+    fi
+}
+
+main "$@"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[pep8]
+max-line-length=80
+ignore=E501,E24

--- a/tests/integration/providers/aws/lambda/test_app_integration.py
+++ b/tests/integration/providers/aws/lambda/test_app_integration.py
@@ -17,9 +17,11 @@ from tight.providers.aws.lambda_app import app
 import tight.providers.aws.controllers.lambda_proxy_event as lambda_proxy
 import importlib
 
+
 @fixture(autouse=True)
 def set_region(monkeypatch):
     monkeypatch.setenv('TIGHT.APP_ROOT', 'fixtures/lambda_app')
+
 
 def test_app_create(empty_module):
     def mock_function(*args, **kwargs):
@@ -30,7 +32,7 @@ def test_app_create(empty_module):
     setattr(empty_module, 'mock_function', mock_function)
     app.create(empty_module)
     assert hasattr(empty_module, 'empty_controller'), 'The empty module has controller attributes.'
-    empty_controller =  importlib.import_module('fixtures.lambda_app.functions.empty_controller.handler')
+    empty_controller = importlib.import_module('fixtures.lambda_app.functions.empty_controller.handler')
     setattr(empty_controller, 'mock_get_handler', mock_function)
     empty_controller.mock_get_handler.func_globals['__package__'] = 'functions.empty_controller'
     empty_controller.mock_get_handler.func_globals['__name__'] = 'fixtures.lambda_app.functions.empty_controller.handler'

--- a/tests/unit/core/test_logger_unit.py
+++ b/tests/unit/core/test_logger_unit.py
@@ -14,11 +14,14 @@
 
 import tight.core.logger as logger
 
+
 def test_no_boom():
     assert True, 'Module can be imported.'
 
+
 def test_logger_info():
     test_message = 'test message'
+
     def info_spy(message):
         assert message == 'test message', 'The message is logged'
     original_info = getattr(logger.logger, 'info')

--- a/tests/unit/core/test_safeget_unit.py
+++ b/tests/unit/core/test_safeget_unit.py
@@ -14,8 +14,10 @@
 
 import tight.core.safeget as safeget
 
+
 def test_no_boom():
     assert True, 'Module can be imported.'
+
 
 def test_safeget():
     some_dict = {

--- a/tests/unit/core/test_test_helpers_unit.py
+++ b/tests/unit/core/test_test_helpers_unit.py
@@ -16,8 +16,10 @@ import os
 import tight.core.test_helpers as test_helpers
 from tight.providers.aws.clients import boto3_client
 
+
 def test_no_boom():
     assert True, 'Module can be imported.'
+
 
 def test_prepare_pills_record():
     test_helpers.prepare_pills('record', 'some/path', boto3_client.session())
@@ -30,6 +32,7 @@ def test_prepare_pills_record():
     assert boto3_pill == boto3_pill_cached, 'boto3 pill is cached'
     assert dynamo_pill == dynamo_pill_cached, 'dynamo pill is cached'
 
+
 def test_prepare_pills_playback():
     test_helpers.prepare_pills('playback', 'some/path', boto3_client.session())
     boto3_pill = getattr(test_helpers, 'boto3_pill')
@@ -41,9 +44,11 @@ def test_prepare_pills_playback():
     assert boto3_pill == boto3_pill_cached, 'boto3 pill is cached'
     assert dynamo_pill == dynamo_pill_cached, 'dynamo pill is cached'
 
+
 def test_placebos_path_playback():
     result = test_helpers.placebos_path('/some/absolute/path.py', 'my_namespace')
     assert result == '/some/absolute/placebos/my_namespace'
+
 
 def test_placebos_path_record(tmpdir):
     test_file = '{}/some_test.py'.format(tmpdir)
@@ -55,6 +60,7 @@ def test_placebos_path_record(tmpdir):
 
     assert result == '{}/placebos/some_test'.format(tmpdir)
     assert os.path.isdir(result), 'Namespaced placebos directory exists'
+
 
 def test_placebos_path_record_placebos_exist(tmpdir):
     test_file = '{}/some_test.py'.format(tmpdir)
@@ -72,4 +78,3 @@ def test_placebos_path_record_placebos_exist(tmpdir):
     assert os.listdir(result)[0] == 'i_should_not_exist.txt'
     result2 = test_helpers.placebos_path(test_file, 'some_test', mode='record')
     assert len(os.listdir(result2)) == 0
-

--- a/tests/unit/providers/aws/clients/test_boto3_client_unit.py
+++ b/tests/unit/providers/aws/clients/test_boto3_client_unit.py
@@ -14,6 +14,7 @@
 
 from tight.providers.aws.clients import boto3_client
 
+
 def test_no_boom():
     assert True, 'Client can be imported.'
 

--- a/tests/unit/providers/aws/clients/test_dynamo_db_unit.py
+++ b/tests/unit/providers/aws/clients/test_dynamo_db_unit.py
@@ -15,14 +15,18 @@
 import os
 from tight.providers.aws.clients import dynamo_db
 
+
 def test_no_boom():
     assert True, 'Client can be imported.'
+
 
 def test_dynamo_db_connect_local():
     setattr(dynamo_db, 'engine', None)
     os.environ['AWS_REGION'] = 'us-west-99'
     os.environ['USE_LOCAL_DB'] = 'True'
+
     class EngineSpy(object):
+
         def connect(self, *args, **kwargs):
             assert kwargs.pop('host') == 'localhost', 'Connect to dynamo locally.'
 
@@ -32,12 +36,15 @@ def test_dynamo_db_connect_local():
     setattr(dynamo_db, 'Engine', EngineSpy)
     dynamo_db.connect()
 
+
 def test_dynamo_db_connect_ci():
     setattr(dynamo_db, 'engine', None)
     os.environ['AWS_REGION'] = 'us-west-99'
     os.environ['CI'] = 'True'
     os.environ.pop('USE_LOCAL_DB')
+
     class EngineSpy(object):
+
         def connect(self, *args, **kwargs):
             raise Exception('Should not call this method.')
 
@@ -47,11 +54,14 @@ def test_dynamo_db_connect_ci():
     setattr(dynamo_db, 'Engine', EngineSpy)
     dynamo_db.connect()
 
+
 def test_dynamo_db_connect_prod():
     setattr(dynamo_db, 'engine', None)
     os.environ['AWS_REGION'] = 'us-west-99'
     os.environ.pop('CI')
+
     class EngineSpy(object):
+
         def connect(self, *args, **kwargs):
             raise Exception('Should not call this method.')
 

--- a/tests/unit/providers/aws/controllers/test_lambda_proxy_event_unit.py
+++ b/tests/unit/providers/aws/controllers/test_lambda_proxy_event_unit.py
@@ -22,25 +22,30 @@ def test_prepare_args_no_boom():
     prepared_args = instance.prepare_args('', {}, {})
     assert prepared_args == {'event': {}, 'context': {}, 'principal_id': None}
 
+
 def test_prepare_args_json_loads_body():
     instance = LambdaProxyController()
     prepared_args = instance.prepare_args('', {'body': '{"name":"banana"}'}, {})
     assert prepared_args == {'event': {'body': {'name': 'banana'}}, 'context': {}, 'principal_id': None}
 
+
 def test_prepare_args_json_loads_body_unparsable():
     instance = LambdaProxyController()
-    prepared_args = instance.prepare_args('', {'body':'I am just a string'}, {})
+    prepared_args = instance.prepare_args('', {'body': 'I am just a string'}, {})
     assert prepared_args == {'event': {'body': {}}, 'context': {}, 'principal_id': None}
+
 
 def test_prepare_response_passthrough():
     instance = LambdaProxyController()
     prepared_response = instance.prepare_response(passthrough='Banana')
     assert prepared_response == 'Banana'
 
+
 def test_prepare_response_default():
     instance = LambdaProxyController()
     prepared_response = instance.prepare_response()
     assert prepared_response == {'body': {}, 'headers': {'Access-Control-Allow-Origin': '*'}, 'statusCode': 200}
+
 
 def test_set_headers():
     set_default_headers({})

--- a/tests/unit/providers/aws/controllers/test_lambda_proxy_event_unit.py
+++ b/tests/unit/providers/aws/controllers/test_lambda_proxy_event_unit.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+import re
+import tight
 from tight.providers.aws.controllers.lambda_proxy_event import LambdaProxyController
 from tight.providers.aws.controllers.lambda_proxy_event import LambdaProxySingleton
 from tight.providers.aws.controllers.lambda_proxy_event import set_default_headers
@@ -54,3 +57,34 @@ def test_set_headers():
     set_default_headers({'Content-Type': 'text/html'})
     prepared_response = LambdaProxySingleton.prepare_response()
     assert prepared_response == {'body': {}, 'headers': {'Content-Type': 'text/html'}, 'statusCode': 200}
+
+
+def test_proxy_controller_run_error_handling(monkeypatch):
+    """ This looks like one big regex literal, however there are some control characters sprinkled in.
+        Hopefully, this will be robust enough to not break frequently. However, if it does look for
+        consider: Did the `lambda_proxy_event.py` module get moved? Did line numbers change enough that
+        pattern to match them is no longer valid?
+    """
+    escaped_text = r"""\
+\
+Traceback\ \(most\ recent\ call\ last\)\:\
+\_\_\ File\ \".*\/tight\/tight\/providers\/aws\/controllers\/lambda\_proxy\_event\.py\"\,\ line\ \d+,\ in\ run\
+\_\_\_\_\ method\_response\ \=\ method\_handler\(\*args\,\ \*\*method\_handler\_args\)\
+\_\_\ File\ \".*\/tight\/tests\/unit\/providers\/aws\/controllers\/test\_lambda\_proxy\_event\_unit\.py\"\,\ line\ \d+,\ in\ controller\_stub\
+\_\_\_\_\ raise\ Exception\(\'I\ am\ an\ error\.\'\)\
+Exception\:\ I\ am\ an\ error\."""
+
+    traceback_assertion_pattern = re.compile(escaped_text)
+    instance = LambdaProxyController()
+
+    def controller_stub(*args, **kwargs):
+        raise Exception('I am an error.')
+    instance.methods['test_controller:GET'] = controller_stub
+
+    def error_spy(*args, **kwargs):
+        match = re.search(traceback_assertion_pattern, kwargs['message'])
+        assert match is not None, 'Error is logged with formatted stacktrace.'
+    monkeypatch.setattr(tight.providers.aws.controllers.lambda_proxy_event, 'error', error_spy)
+    response = instance.run('test_controller', {'httpMethod': 'GET'}, {})
+    assert response['statusCode'] == 500
+    assert response['body'] == 'There was an error.'

--- a/tests/unit/providers/aws/lambda/test_app_unit.py
+++ b/tests/unit/providers/aws/lambda/test_app_unit.py
@@ -17,13 +17,16 @@ import pytest
 from pytest import fixture
 from tight.providers.aws.lambda_app import app
 
+
 @fixture(autouse=True)
 def set_region(monkeypatch):
     monkeypatch.setenv('TIGHT.APP_ROOT', 'fixtures/lambda_app')
 
+
 def test_collect_controllers():
     controllers = app.collect_controllers()
-    assert controllers == [{'empty_controller': 'fixtures.lambda_app.functions.empty_controller.handler'},{'fake_lambda_proxy_controller': 'fixtures.lambda_app.functions.fake_lambda_proxy_controller.handler'}]
+    assert controllers == [{'empty_controller': 'fixtures.lambda_app.functions.empty_controller.handler'}, {'fake_lambda_proxy_controller': 'fixtures.lambda_app.functions.fake_lambda_proxy_controller.handler'}]
+
 
 def test_app_run_success():
     def successful_create(module):
@@ -32,9 +35,11 @@ def test_app_run_success():
     sys.modules.setdefault('app_index', True)
     app.run()
 
+
 def test_app_run_failure():
     with pytest.raises(Exception):
         sys.modules.setdefault('app_index', True)
+
         def create_failure(module):
             raise Exception
         app.create = create_failure

--- a/tight/core/logger.py
+++ b/tight/core/logger.py
@@ -18,6 +18,7 @@ logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 def info(*args, **kwargs):
     """
     Log a message using the system logger.

--- a/tight/core/logger.py
+++ b/tight/core/logger.py
@@ -29,3 +29,8 @@ def info(*args, **kwargs):
     """
     message = kwargs.pop('message')
     logger.info(message)
+
+
+def error(*args, **kwargs):
+    message = kwargs.pop('message')
+    logger.error(message)

--- a/tight/core/safeget.py
+++ b/tight/core/safeget.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 def safeget(dct, *keys):
     for key in keys:
         try:

--- a/tight/core/test_helpers.py
+++ b/tight/core/test_helpers.py
@@ -12,21 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest, os, sys, importlib, yaml, json, shutil
+import pytest
+import os
+import sys
+import importlib
+import yaml
+import json
+import shutil
 from botocore import session as boto_session
 from tight.providers.aws.clients import boto3_client
 from tight.providers.aws.clients import dynamo_db
 import placebo
 
+
 @pytest.fixture
 def app():
     return importlib.import_module('app_index')
+
 
 @pytest.fixture
 def event():
     with open('tests/fixtures/lambda_proxy_event.yml') as data_file:
         event = yaml.load(data_file)
     return event
+
 
 def placebos_path(file, namespace, mode='playback'):
     test_path = '/'.join(file.split('/')[0:-1])
@@ -40,9 +49,11 @@ def placebos_path(file, namespace, mode='playback'):
             os.mkdir(namespaced_path)
     return namespaced_path
 
+
 def spy_on_session(file, session, placebo_path):
     pill = placebo.attach(session, data_path=placebo_path)
     return pill
+
 
 def prepare_pills(mode, placebo_path, dynamo_db_session):
     this = sys.modules[__name__]
@@ -66,16 +77,20 @@ def prepare_pills(mode, placebo_path, dynamo_db_session):
         boto3_pill_method = getattr(boto3_pill, mode)
         boto3_pill_method()
 
+
 def tape_deck(mode, file, dynamo_db_session, namespace):
     placebo_path = placebos_path(file, namespace, mode=mode)
     os.environ[mode.upper()] = 'True'
     prepare_pills(mode, placebo_path, dynamo_db_session)
 
+
 def record(file, dynamo_db_session, namespace):
     tape_deck('record', file, dynamo_db_session, namespace)
 
+
 def playback(file, dynamo_db_session, namespace):
     tape_deck('playback', file, dynamo_db_session, namespace)
+
 
 def expected_response_body(dir, expectation_file, actual_response):
     file_path = '/'.join([dir, expectation_file])
@@ -89,7 +104,7 @@ def expected_response_body(dir, expectation_file, actual_response):
 
 @pytest.fixture
 def dynamo_db_session():
-    session =  getattr(dynamo_db, 'session') or None
+    session = getattr(dynamo_db, 'session') or None
     if session:
         return session
     else:

--- a/tight/providers/aws/clients/boto3_client.py
+++ b/tight/providers/aws/clients/boto3_client.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import boto3, sys
+import boto3
+import sys
 boto3_session = None
+
+
 def session():
     current_module = sys.modules[__name__]
     boto3_session = getattr(current_module, 'boto3_session')

--- a/tight/providers/aws/clients/dynamo_db.py
+++ b/tight/providers/aws/clients/dynamo_db.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 from flywheel import Model, Field, Engine
-import os, sys
+import os
+import sys
 current_module = sys.modules[__name__]
 session = None
 engine = None
+
 
 def connect(*args, **kwargs):
     engine = getattr(current_module, 'engine')

--- a/tight/providers/aws/controllers/lambda_proxy_event.py
+++ b/tight/providers/aws/controllers/lambda_proxy_event.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, importlib, json, traceback
+import sys
+import importlib
+import json
+import traceback
 from functools import partial
 from tight.core.logger import info
 
 methods = [
     'get', 'post', 'patch', 'put', 'delete', 'options'
 ]
+
 
 def merge_dicts(*dict_args):
     """
@@ -29,6 +33,7 @@ def merge_dicts(*dict_args):
     for dictionary in dict_args:
         result.update(dictionary)
     return result
+
 
 class LambdaProxyController():
     HEADERS = {
@@ -45,7 +50,6 @@ class LambdaProxyController():
                 self.methods['{}:{}'.format(controller_name, method.upper())] = func
             setattr(self, method, partial(function, method, self=self))
 
-
     def attach_handler(self, func):
         function_package = func.func_globals['__name__']
         function_module = importlib.import_module(function_package)
@@ -53,7 +57,6 @@ class LambdaProxyController():
             getattr(function_module, 'handler')
         except Exception as e:
             setattr(function_module, 'handler', self.run)
-
 
     def prepare_args(self, *args, **kwargs):
         event = args[1]
@@ -118,14 +121,17 @@ LambdaProxySingleton = LambdaProxyController()
 
 current_module = sys.modules[__name__]
 
+
 def expose():
     for method in methods:
         handler = getattr(LambdaProxySingleton, method)
         setattr(current_module, method, handler)
 expose()
 
+
 def set_default_headers(headers):
     LambdaProxySingleton.HEADERS = headers
+
 
 def handler(*args, **kwargs):
     """ Proxy to LambdaProxySingleton::run

--- a/tight/providers/aws/lambda_app/app.py
+++ b/tight/providers/aws/lambda_app/app.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, importlib, traceback, sys
+import os
+import importlib
+import traceback
+import sys
 from functools import partial
 from tight.core.logger import info
+
 
 def run():
     """ Call create on ``sys.modules['app_index']`` and catch any errors.
@@ -98,6 +102,7 @@ def create(current_module):
     controllers = collect_controllers()
     for item in controllers:
         name, controller_module_path = item.popitem()
+
         def function(*args, **kwargs):
             controller_module_path = args[0]
             func_args = args[1:4]
@@ -106,6 +111,7 @@ def create(current_module):
         bound_function = partial(function, *(controller_module_path, name))
         function.__name__ = name + '_module'
         setattr(current_module, name, bound_function)
+
 
 def collect_controllers():
     """" Inspect the application directory structure and discover controller modules.


### PR DESCRIPTION
- Better stack trace dumps on error
- First pass as pep8 enforcement and cleanup; adapted from some shell scripts :/ should port functionality to python, but this gets us off the ground
- Add autopep8 to dependencies.
- Added ./run_autopep8.sh script to run autopep8
- ./run_autopep8 check will run autopep8 on ./tight and ./tests
- ./run_autopep8 fix will run autopep8 on ./tight and ./tests and automatically fix
- ./run_autopep8 with no arguments will run autopep8 on changed files according to git
- Add check to travis config; builds will fail if ./run_autopep8 fix exits non-zero