### PR TITLE
Move to support python 3.6 runtime.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ language: python
 sudo: false
 matrix:
   include:
-  - python: "2.7"
+  - python: "3.6"
 beforeinstall:
     - apt-get update
     - apt-get install colordiff

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,4 @@ python-dateutil==2.6.0
 six==1.10.0
 pytest-cov
 autopep8
+pylint~=1.7

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ with open('README.rst') as readme_file:
 install_requires = [
     'flywheel>=0.5.1',
     'PyYAML',
-    'boto3',
-    'placebo'
+    'boto3'
 ]
 
 

--- a/tests/integration/providers/aws/lambda/test_app_integration.py
+++ b/tests/integration/providers/aws/lambda/test_app_integration.py
@@ -34,8 +34,7 @@ def test_app_create(empty_module):
     assert hasattr(empty_module, 'empty_controller'), 'The empty module has controller attributes.'
     empty_controller = importlib.import_module('fixtures.lambda_app.functions.empty_controller.handler')
     setattr(empty_controller, 'mock_get_handler', mock_function)
-    empty_controller.mock_get_handler.func_globals['__package__'] = 'functions.empty_controller'
-    empty_controller.mock_get_handler.func_globals['__name__'] = 'fixtures.lambda_app.functions.empty_controller.handler'
+    setattr(empty_controller.mock_get_handler, '__module__', 'fixtures.lambda_app.functions.empty_controller.handler')
     lambda_proxy.get(empty_controller.mock_get_handler)
     result = empty_module.empty_controller({'body': None, 'httpMethod': 'GET'}, {})
     assert result['body'] == 'GOOD TO GO'

--- a/tests/unit/core/test_test_helpers_unit.py
+++ b/tests/unit/core/test_test_helpers_unit.py
@@ -12,69 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import tight.core.test_helpers as test_helpers
-from tight.providers.aws.clients import boto3_client
 
 
 def test_no_boom():
     assert True, 'Module can be imported.'
-
-
-def test_prepare_pills_record():
-    test_helpers.prepare_pills('record', 'some/path', boto3_client.session())
-    boto3_pill = getattr(test_helpers, 'boto3_pill')
-    dynamo_pill = getattr(test_helpers, 'pill')
-    # Do it again and make sure objects are the same
-    test_helpers.prepare_pills('record', 'some/path', boto3_client.session())
-    boto3_pill_cached = getattr(test_helpers, 'boto3_pill')
-    dynamo_pill_cached = getattr(test_helpers, 'pill')
-    assert boto3_pill == boto3_pill_cached, 'boto3 pill is cached'
-    assert dynamo_pill == dynamo_pill_cached, 'dynamo pill is cached'
-
-
-def test_prepare_pills_playback():
-    test_helpers.prepare_pills('playback', 'some/path', boto3_client.session())
-    boto3_pill = getattr(test_helpers, 'boto3_pill')
-    dynamo_pill = getattr(test_helpers, 'pill')
-    # Do it again and make sure objects are the same
-    test_helpers.prepare_pills('playback', 'some/path', boto3_client.session())
-    boto3_pill_cached = getattr(test_helpers, 'boto3_pill')
-    dynamo_pill_cached = getattr(test_helpers, 'pill')
-    assert boto3_pill == boto3_pill_cached, 'boto3 pill is cached'
-    assert dynamo_pill == dynamo_pill_cached, 'dynamo pill is cached'
-
-
-def test_placebos_path_playback():
-    result = test_helpers.placebos_path('/some/absolute/path.py', 'my_namespace')
-    assert result == '/some/absolute/placebos/my_namespace'
-
-
-def test_placebos_path_record(tmpdir):
-    test_file = '{}/some_test.py'.format(tmpdir)
-    with file(test_file, 'w') as tmp_test_file:
-        tmp_test_file.write('')
-
-    tmpdir.mkdir('placebos')
-    result = test_helpers.placebos_path(test_file, 'some_test', mode='record')
-
-    assert result == '{}/placebos/some_test'.format(tmpdir)
-    assert os.path.isdir(result), 'Namespaced placebos directory exists'
-
-
-def test_placebos_path_record_placebos_exist(tmpdir):
-    test_file = '{}/some_test.py'.format(tmpdir)
-    with file(test_file, 'w') as tmp_test_file:
-        tmp_test_file.write('')
-
-    tmpdir.mkdir('placebos')
-    result = test_helpers.placebos_path(test_file, 'some_test', mode='record')
-
-    assert result == '{}/placebos/some_test'.format(tmpdir)
-    assert os.path.isdir(result), 'Namespaced placebos directory exists'
-    disappearing_file = '{}/i_should_not_exist.txt'.format(result)
-    with file(disappearing_file, 'w') as file_to_make_dissapear:
-        file_to_make_dissapear.write('make me disappear')
-    assert os.listdir(result)[0] == 'i_should_not_exist.txt'
-    result2 = test_helpers.placebos_path(test_file, 'some_test', mode='record')
-    assert len(os.listdir(result2)) == 0


### PR DESCRIPTION
* Remove test helpers that inject placebo; it's not python3 compatible and the overall approach needs to be rethought.
* Minor refactors to be compatible with Python 3.6

Should resolve #5 