### PR TITLE
Proposal: Allow applications to immediately return arbitrary responses.

### DIFF
--- a/tests/integration/providers/aws/lambda/test_app_integration.py
+++ b/tests/integration/providers/aws/lambda/test_app_integration.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib
+from functools import wraps
 
 from pytest import fixture
 from tight.providers.aws.lambda_app import app
 import tight.providers.aws.controllers.lambda_proxy_event as lambda_proxy
-import importlib
 
 
 @fixture(autouse=True)
@@ -38,3 +39,44 @@ def test_app_create(empty_module):
     lambda_proxy.get(empty_controller.mock_get_handler)
     result = empty_module.empty_controller({'body': None, 'httpMethod': 'GET'}, {})
     assert result['body'] == 'GOOD TO GO'
+
+
+def test_app_404(empty_module):
+    """
+    Test the scenario where your handler is wrapped by another function, such as an access or capability checker.
+
+    E.g.
+
+    @lambda_proxy.get
+    @check_access
+    def get_handler(*args, **kwargs):
+        pass
+
+    We want the wrapper to be able to return a response.
+
+    :param empty_module:
+    :return:
+    """
+    def test_wrapper(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            lambda_proxy.exit_with_response(404, {'body': 'Not found.', 'headers': {'Content-Type': 'text/html'}})
+            return f(*args, **kwargs)
+        return wrapper
+
+    @test_wrapper
+    def mock_function(*args, **kwargs):
+        return {
+            'statusCode': 200,
+            'body': 'GOOD TO GO'
+        }
+
+    setattr(empty_module, 'mock_function', mock_function)
+    app.create(empty_module)
+    assert hasattr(empty_module, 'empty_controller'), 'The empty module has controller attributes.'
+    empty_controller = importlib.import_module('fixtures.lambda_app.functions.empty_controller.handler')
+    setattr(empty_controller, 'mock_get_handler', mock_function)
+    setattr(empty_controller.mock_get_handler, '__module__', 'fixtures.lambda_app.functions.empty_controller.handler')
+    lambda_proxy.get(empty_controller.mock_get_handler)
+    result = empty_module.empty_controller({'body': None, 'httpMethod': 'GET'}, {})
+    assert result == {'body': 'Not found.', 'statusCode': 404, 'headers': {'Content-Type': 'text/html', 'Access-Control-Allow-Origin': '*'}}


### PR DESCRIPTION
* Expose `exit_with_response` method on `lambda_proxy_event`
* Allows for _flexible_ exits.
* From branch within your handler you can call something like:
  `lambda_proxy.exit_with_response(404, {'body': 'Not found.', 'headers': {'Content-Type': 'text/html'}})`
  and your lambda will immediately exit with the given http response code and body.
* Preserve default header behavior and otherwise maintain consistency with existing response construction process.